### PR TITLE
feat: upgrade to fbsim-core v1.0.0-alpha.8 for tie resim feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75ecac989d1fc64c89817c03430e6241be29dc17f8b6ecc06c81614c65c63f4"
+checksum = "2d0f8bb728ddb821141b908f689c7b3a2fb8b7805f407de2f4a96a1274ccbffe"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-api"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 dependencies = [
  "fbsim-core",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-api"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fbsim-core = { version = "1.0.0-alpha.5", features = ["rocket_okapi"] }
+fbsim-core = { version = "1.0.0-alpha.8", features = ["rocket_okapi"] }
 rand = "0.8.5"
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_cors = "0.6.0"


### PR DESCRIPTION
In this PR, I upgrade to the latest `fbsim-core` version to bring in its newly developed tie re-simulation feature

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/15