### PR TITLE
chore: upgrade to fbsim-core v1.0.0-alpha.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-api"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "fbsim-core",
  "rand",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0f8bb728ddb821141b908f689c7b3a2fb8b7805f407de2f4a96a1274ccbffe"
+checksum = "fcebe85c3cb0f83a7a89ae42691963416ab8500e82c941b68047ef5802170baf"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fbsim-api"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fbsim-core = { version = "1.0.0-alpha.8", features = ["rocket_okapi"] }
+fbsim-core = { version = "1.0.0-alpha.13", features = ["rocket_okapi"] }
 rand = "0.8.5"
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_cors = "0.6.0"


### PR DESCRIPTION
In this PR, I upgrade to fbsim-core v1.0.0-alpha.13 to bring in a fix mentioned in my fbsim-cli PR to add new benchmarks for the model:
- https://github.com/whatsacomputertho/fbsim-cli/pull/7

Specifically,
> I also found that there was a bug in the core model - I had the coefficient and the intercept backwards - which led to worse teams performing better overall against better opponents.